### PR TITLE
Use svg version of Travis build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### hapi-auth-basic
 
-[![Build Status](https://secure.travis-ci.org/hapijs/hapi-auth-basic.png)](http://travis-ci.org/hapijs/hapi-auth-basic)
+[![Build Status](https://secure.travis-ci.org/hapijs/hapi-auth-basic.svg)](http://travis-ci.org/hapijs/hapi-auth-basic)
 
 Lead Maintainer: [Eran Hammer](https://github.com/hueniverse)
 


### PR DESCRIPTION
This PR changes the Travis build badge from low resolution png to a scalable svg version.