### PR TITLE
add option to pass attributes to unauthorized replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Basic authentication requires validating a username and password combination. Th
           included when `isValid` is `true`, but there are cases when the application needs to know who tried to authenticate even when it fails
           (e.g. with authentication mode `'try'`).
 - `allowEmptyUsername` - (optional) if `true`, allows making requests with an empty username. Defaults to `false`.
+- `unauthorizedAttributes` - (optional) if set, passed directly to [Boom.unauthorized](https://github.com/hapijs/boom#boomunauthorizedmessage-scheme-attributes). Useful for setting realm attribute in WWW-Authenticate header. Defaults to `undefined`.
 
 ```javascript
 const Bcrypt = require('bcrypt');

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,13 +36,13 @@ internals.implementation = function (server, options) {
             const req = request.raw.req;
             const authorization = req.headers.authorization;
             if (!authorization) {
-                return reply(Boom.unauthorized(null, 'Basic'));
+                return reply(Boom.unauthorized(null, 'Basic', settings.unauthorizedAttributes));
             }
 
             const parts = authorization.split(/\s+/);
 
             if (parts[0].toLowerCase() !== 'basic') {
-                return reply(Boom.unauthorized(null, 'Basic'));
+                return reply(Boom.unauthorized(null, 'Basic', settings.unauthorizedAttributes));
             }
 
             if (parts.length !== 2) {
@@ -59,7 +59,7 @@ internals.implementation = function (server, options) {
             const password = credentialsPart.slice(sep + 1);
 
             if (!username && !settings.allowEmptyUsername) {
-                return reply(Boom.unauthorized('HTTP authentication header missing username', 'Basic'));
+                return reply(Boom.unauthorized('HTTP authentication header missing username', 'Basic', settings.unauthorizedAttributes));
             }
 
             settings.validateFunc(request, username, password, (err, isValid, credentials) => {
@@ -71,7 +71,7 @@ internals.implementation = function (server, options) {
                 }
 
                 if (!isValid) {
-                    return reply(Boom.unauthorized('Bad username or password', 'Basic'), null, { credentials: credentials });
+                    return reply(Boom.unauthorized('Bad username or password', 'Basic', settings.unauthorizedAttributes), null, { credentials: credentials });
                 }
 
                 if (!credentials ||
@@ -89,5 +89,3 @@ internals.implementation = function (server, options) {
 
     return scheme;
 };
-
-

--- a/test/index.js
+++ b/test/index.js
@@ -741,6 +741,41 @@ it('accepts request object in validateFunc', (done) => {
     });
 });
 
+it('includes additional attributes in WWW-Authenticate header', (done) => {
+
+    const server = new Hapi.Server();
+    server.connection();
+    server.register(require('../'), (err) => {
+
+        expect(err).to.not.exist();
+        server.auth.strategy('default', 'basic', 'required', {
+            validateFunc: internals.user,
+            unauthorizedAttributes: { realm: 'hapi' }
+        });
+        server.route({
+            method: 'POST',
+            path: '/',
+            handler: function (request, reply) {
+
+                return reply('ok');
+            },
+            config: {
+                auth: 'default'
+            }
+        });
+
+        const request = { method: 'POST', url: '/' };
+
+        server.inject(request, (res) => {
+
+            const wwwAuth = 'www-authenticate';
+            expect(res.headers).to.include(wwwAuth);
+            expect(res.headers[wwwAuth]).to.equal('Basic realm=\"hapi\"');
+            done();
+        });
+    });
+});
+
 
 internals.header = function (username, password) {
 


### PR DESCRIPTION
This addition allows someone to optionally specify an attributes object to pass to [Boom.unauthorized](https://github.com/hapijs/boom#boomunauthorizedmessage-scheme-attributes).

Some backstory: AWS SNS allows subscriptions from HTTPS endpoints with basic authentication. Their confirmation flow involves an initial unauthenticated request to the endpoint followed by an authenticated request. I wasn't receiving the second authenticated request because the `WWW-Authentication` header didn't specify a realm (e.g. `WWW-Authentication: Basic realm="hapi"`). Thankfully, `Boom.unauthorized` made this easy to add.