### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Basic authentication requires validating a username and password combination. Th
     - `username` - the username received from the client.
     - `password` - the password received from the client.
     - `callback` - a callback function with the signature `function(err, isValid, credentials)` where:
-        - `err` - an internal error.
+        - `err` - an internal error. If defined will replace default Boom.unauthorized error
         - `isValid` - `true` if both the username was found and the password matched, otherwise `false`.
         - `credentials` - a credentials object passed back to the application in `request.auth.credentials`. Typically, `credentials` are only
           included when `isValid` is `true`, but there are cases when the application needs to know who tried to authenticate even when it fails
           (e.g. with authentication mode `'try'`).
 - `allowEmptyUsername` - (optional) if `true`, allows making requests with an empty username. Defaults to `false`.
-- `unauthorizedAttributes` - (optional) if set, passed directly to [Boom.unauthorized](https://github.com/hapijs/boom#boomunauthorizedmessage-scheme-attributes). Useful for setting realm attribute in WWW-Authenticate header. Defaults to `undefined`.
+- `unauthorizedAttributes` - (optional) if set, passed directly to [Boom.unauthorized](https://github.com/hapijs/boom#boomunauthorizedmessage-scheme-attributes) if no custom `err` is defined. Useful for setting realm attribute in WWW-Authenticate header. Defaults to `undefined`.
 
 ```javascript
 const Bcrypt = require('bcrypt');


### PR DESCRIPTION
If took me some time to figure out that if a value is passed to the `err` parameter of the validation function callback, this would replace the default Boom.unauthorized error. My simple text error message was always returned as such with an HTTP OK status.

The proposed README update should hopefully help and clarify it