### PR TITLE
Update for hapi 17.x.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ lib-cov
 *.swp
 *.swo
 *.swn
-
+package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+*
+!lib/**
+!.npmignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 
 node_js:
-  - "4"
-  - "6"
+  - "8"
+  - "9"
+  - "node"
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ const users = {
     }
 };
 
-const validate = async (request, username, password) => {
+const validate = async (request, username, password, h) => {
+
+    if (username === 'help') {
+        return { response: h.redirect('https://hapijs.com/help') };     // custom response
+    }
 
     const user = users[username];
     if (!user) {
@@ -50,7 +54,7 @@ const main = async () => {
 
     const server = Hapi.server({ port: 4000 });
 
-    await server.register(require('.'));
+    await server.register(require('hapi-auth-basic'));
 
     server.auth.strategy('simple', 'basic', { validate });
     server.auth.default('simple');

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Basic authentication requires validating a username and password combination. Th
     - `username` - the username received from the client.
     - `password` - the password received from the client.
     - `h` - the response toolkit.
-    - Returns an object `{ isValid, credentials, takeover }` where:
+    - Returns an object `{ isValid, credentials, response }` where:
         - `isValid` - `true` if both the username was found and the password matched, otherwise `false`.
         - `credentials` - a credentials object passed back to the application in `request.auth.credentials`.
-        - `takeover` - Optional. If provided will be used immediately as a takeover response. Can be used to redirect the client, for example. Don't need to provide `isValid` or `credentials` if `takeover` is provided
+        - `response` - Optional. If provided will be used immediately as a takeover response. Can be used to redirect the client, for example. Don't need to provide `isValid` or `credentials` if `response` is provided
     - Throwing an error from this function will replace default `Boom.unauthorized` error
     - Typically, `credentials` are only included when `isValid` is `true`, but there are cases when the application needs to know who tried to authenticate even when it fails (e.g. with authentication mode `'try'`).
 - `allowEmptyUsername` - (optional) if `true`, allows making requests with an empty username. Defaults to `false`.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const users = {
     }
 };
 
-const validate = async (request, username, password, h) => {
+const validate = async (request, username, password) => {
 
     const user = users[username];
     if (!user) {
@@ -48,7 +48,7 @@ const validate = async (request, username, password, h) => {
 
 const main = async () => {
 
-    const server = new Hapi.Server({ port: 4000 });
+    const server = Hapi.server({ port: 4000 });
 
     await server.register(require('.'));
 

--- a/README.md
+++ b/README.md
@@ -6,21 +6,23 @@ Lead Maintainer: [Matt Harrison](https://github.com/mtharrison)
 
 Basic authentication requires validating a username and password combination. The `'basic'` scheme takes the following options:
 
-- `validateFunc` - (required) a user lookup and password validation function with the signature `function(request, username, password, callback)` where:
+- `validate` - (required) a user lookup and password validation function with the signature `[async] function(request, username, password, h)` where:
     - `request` - is the hapi request object of the request which is being authenticated.
     - `username` - the username received from the client.
     - `password` - the password received from the client.
-    - `callback` - a callback function with the signature `function(err, isValid, credentials)` where:
-        - `err` - an internal error. If defined will replace default `Boom.unauthorized` error
+    - `h` - the response toolkit.
+    - Returns an object `{ isValid, credentials, takeover }` where:
         - `isValid` - `true` if both the username was found and the password matched, otherwise `false`.
-        - `credentials` - a credentials object passed back to the application in `request.auth.credentials`. Typically, `credentials` are only
-          included when `isValid` is `true`, but there are cases when the application needs to know who tried to authenticate even when it fails
-          (e.g. with authentication mode `'try'`).
+        - `credentials` - a credentials object passed back to the application in `request.auth.credentials`.
+        - `takeover` - Optional. If provided will be used immediately as a takeover response. Can be used to redirect the client, for example. Don't need to provide `isValid` or `credentials` if `takeover` is provided
+    - Throwing an error from this function will replace default `Boom.unauthorized` error
+    - Typically, `credentials` are only included when `isValid` is `true`, but there are cases when the application needs to know who tried to authenticate even when it fails (e.g. with authentication mode `'try'`).
 - `allowEmptyUsername` - (optional) if `true`, allows making requests with an empty username. Defaults to `false`.
-- `unauthorizedAttributes` - (optional) if set, passed directly to [Boom.unauthorized](https://github.com/hapijs/boom#boomunauthorizedmessage-scheme-attributes) if no custom `err` is defined. Useful for setting realm attribute in WWW-Authenticate header. Defaults to `undefined`.
+- `unauthorizedAttributes` - (optional) if set, passed directly to [Boom.unauthorized](https://github.com/hapijs/boom#boomunauthorizedmessage-scheme-attributes) if no custom `err` is thrown. Useful for setting realm attribute in WWW-Authenticate header. Defaults to `undefined`.
 
 ```javascript
 const Bcrypt = require('bcrypt');
+const Hapi = require('hapi');
 
 const users = {
     john: {
@@ -31,22 +33,47 @@ const users = {
     }
 };
 
-const validate = function (request, username, password, callback) {
+const validate = async (request, username, password, h) => {
 
     const user = users[username];
     if (!user) {
-        return callback(null, false);
+        return { credentials: null, isValid: false };
     }
 
-    Bcrypt.compare(password, user.password, (err, isValid) => {
+    const isValid = await Bcrypt.compare(password, user.password);
+    const credentials = { id: user.id, name: user.name };
 
-        callback(err, isValid, { id: user.id, name: user.name });
-    });
+    return { isValid, credentials };
 };
 
-server.register(require('hapi-auth-basic'), (err) => {
+const main = async () => {
 
-    server.auth.strategy('simple', 'basic', { validateFunc: validate });
-    server.route({ method: 'GET', path: '/', config: { auth: 'simple' } });
+    const server = new Hapi.Server({ port: 4000 });
+
+    await server.register(require('.'));
+
+    server.auth.strategy('simple', 'basic', { validate });
+    server.auth.default('simple');
+
+    server.route({
+        method: 'GET',
+        path: '/',
+        handler: function (request, h) {
+
+            return 'welcome';
+        }
+    });
+
+    await server.start();
+
+    return server;
+};
+
+main()
+.then((server) => console.log(`Server listening on ${server.info.uri}`))
+.catch((err) => {
+
+    console.error(err);
+    process.exit(1);
 });
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,79 +11,78 @@ const Hoek = require('hoek');
 const internals = {};
 
 
-exports.register = function (plugin, options, next) {
+exports.plugin = {
+    pkg: require('../package.json'),
+    register: function (server) {
 
-    plugin.auth.scheme('basic', internals.implementation);
-    next();
-};
-
-
-exports.register.attributes = {
-    pkg: require('../package.json')
+        server.auth.scheme('basic', internals.implementation);
+    }
 };
 
 
 internals.implementation = function (server, options) {
 
     Hoek.assert(options, 'Missing basic auth strategy options');
-    Hoek.assert(typeof options.validateFunc === 'function', 'options.validateFunc must be a valid function in basic scheme');
+    Hoek.assert(typeof options.validate === 'function', 'options.validate must be a valid function in basic scheme');
 
     const settings = Hoek.clone(options);
 
     const scheme = {
-        authenticate: function (request, reply) {
+        authenticate: async function (request, h) {
 
-            const req = request.raw.req;
-            const authorization = req.headers.authorization;
+            const authorization = request.headers.authorization;
+
             if (!authorization) {
-                return reply(Boom.unauthorized(null, 'Basic', settings.unauthorizedAttributes));
+                return h.unauthenticated(Boom.unauthorized(null, 'Basic', settings.unauthorizedAttributes));
             }
 
             const parts = authorization.split(/\s+/);
 
             if (parts[0].toLowerCase() !== 'basic') {
-                return reply(Boom.unauthorized(null, 'Basic', settings.unauthorizedAttributes));
+                return h.unauthenticated(Boom.unauthorized(null, 'Basic', settings.unauthorizedAttributes));
             }
 
             if (parts.length !== 2) {
-                return reply(Boom.badRequest('Bad HTTP authentication header format', 'Basic'));
+                return h.unauthenticated(Boom.badRequest('Bad HTTP authentication header format', 'Basic'));
             }
 
-            const credentialsPart = new Buffer(parts[1], 'base64').toString();
+            const credentialsPart = Buffer.from(parts[1], 'base64').toString();
             const sep = credentialsPart.indexOf(':');
             if (sep === -1) {
-                return reply(Boom.badRequest('Bad header internal syntax', 'Basic'));
+                return h.unauthenticated(Boom.badRequest('Bad header internal syntax', 'Basic'));
             }
 
             const username = credentialsPart.slice(0, sep);
             const password = credentialsPart.slice(sep + 1);
 
-            if (!username && !settings.allowEmptyUsername) {
-                return reply(Boom.unauthorized('HTTP authentication header missing username', 'Basic', settings.unauthorizedAttributes));
+            if (!username &&
+                !settings.allowEmptyUsername) {
+
+                return h.unauthenticated(Boom.unauthorized('HTTP authentication header missing username', 'Basic', settings.unauthorizedAttributes));
             }
 
-            settings.validateFunc(request, username, password, (err, isValid, credentials) => {
+            try {
+                const { isValid, credentials, takeover } = await settings.validate(request, username, password, h);
 
-                credentials = credentials || null;
-
-                if (err) {
-                    return reply(err, null, { credentials: credentials });
+                if (takeover !== undefined) {
+                    return h.response(takeover).takeover();
                 }
 
                 if (!isValid) {
-                    return reply(Boom.unauthorized('Bad username or password', 'Basic', settings.unauthorizedAttributes), null, { credentials: credentials });
+                    return h.unauthenticated(Boom.unauthorized('Bad username or password', 'Basic', settings.unauthorizedAttributes), credentials ? { credentials } : null);
                 }
 
                 if (!credentials ||
                     typeof credentials !== 'object') {
 
-                    return reply(Boom.badImplementation('Bad credentials object received for Basic auth validation'));
+                    return h.unauthenticated(Boom.badImplementation('Bad credentials object received for Basic auth validation'));
                 }
 
-                // Authenticated
-
-                return reply.continue({ credentials: credentials });
-            });
+                return h.authenticated({ credentials });
+            }
+            catch (err) {
+                return h.unauthenticated(err);
+            }
         }
     };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,23 +33,23 @@ internals.implementation = function (server, options) {
             const authorization = request.headers.authorization;
 
             if (!authorization) {
-                return h.unauthenticated(Boom.unauthorized(null, 'Basic', settings.unauthorizedAttributes));
+                throw Boom.unauthorized(null, 'Basic', settings.unauthorizedAttributes);
             }
 
             const parts = authorization.split(/\s+/);
 
             if (parts[0].toLowerCase() !== 'basic') {
-                return h.unauthenticated(Boom.unauthorized(null, 'Basic', settings.unauthorizedAttributes));
+                throw Boom.unauthorized(null, 'Basic', settings.unauthorizedAttributes);
             }
 
             if (parts.length !== 2) {
-                return h.unauthenticated(Boom.badRequest('Bad HTTP authentication header format', 'Basic'));
+                throw Boom.badRequest('Bad HTTP authentication header format', 'Basic');
             }
 
             const credentialsPart = Buffer.from(parts[1], 'base64').toString();
             const sep = credentialsPart.indexOf(':');
             if (sep === -1) {
-                return h.unauthenticated(Boom.badRequest('Bad header internal syntax', 'Basic'));
+                throw Boom.badRequest('Bad header internal syntax', 'Basic');
             }
 
             const username = credentialsPart.slice(0, sep);
@@ -58,31 +58,26 @@ internals.implementation = function (server, options) {
             if (!username &&
                 !settings.allowEmptyUsername) {
 
-                return h.unauthenticated(Boom.unauthorized('HTTP authentication header missing username', 'Basic', settings.unauthorizedAttributes));
+                throw Boom.unauthorized('HTTP authentication header missing username', 'Basic', settings.unauthorizedAttributes);
             }
 
-            try {
-                const { isValid, credentials, takeover } = await settings.validate(request, username, password, h);
+            const { isValid, credentials, response } = await settings.validate(request, username, password, h);
 
-                if (takeover !== undefined) {
-                    return h.response(takeover).takeover();
-                }
-
-                if (!isValid) {
-                    return h.unauthenticated(Boom.unauthorized('Bad username or password', 'Basic', settings.unauthorizedAttributes), credentials ? { credentials } : null);
-                }
-
-                if (!credentials ||
-                    typeof credentials !== 'object') {
-
-                    return h.unauthenticated(Boom.badImplementation('Bad credentials object received for Basic auth validation'));
-                }
-
-                return h.authenticated({ credentials });
+            if (response !== undefined) {
+                return h.response(response).takeover();
             }
-            catch (err) {
-                return h.unauthenticated(err);
+
+            if (!isValid) {
+                return h.unauthenticated(Boom.unauthorized('Bad username or password', 'Basic', settings.unauthorizedAttributes), credentials ? { credentials } : null);
             }
+
+            if (!credentials ||
+                typeof credentials !== 'object') {
+
+                throw Boom.badImplementation('Bad credentials object received for Basic auth validation');
+            }
+
+            return h.authenticated({ credentials });
         }
     };
 

--- a/package.json
+++ b/package.json
@@ -11,19 +11,20 @@
     "basic"
   ],
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.9.0"
   },
   "dependencies": {
-    "boom": "3.x.x",
-    "hoek": "4.x.x"
+    "boom": "7.x.x",
+    "bounce": "^1.2.0",
+    "hoek": "5.x.x"
   },
   "peerDependencies": {
-    "hapi": ">=10.x.x"
+    "hapi": ">=17.x.x"
   },
   "devDependencies": {
-    "code": "2.x.x",
-    "hapi": "13.x.x",
-    "lab": "10.x.x"
+    "code": "5.x.x",
+    "hapi": "17.x.x",
+    "lab": "15.x.x"
   },
   "scripts": {
     "test": "lab -a code -t 100 -L",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "boom": "7.x.x",
-    "bounce": "^1.2.0",
     "hoek": "5.x.x"
   },
   "peerDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -22,7 +22,7 @@ const expect = Code.expect;
 
 it('returns a reply on successful auth', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
     server.auth.strategy('default', 'basic', { validate: internals.user });
 
@@ -46,7 +46,7 @@ it('returns a reply on successful auth', async () => {
 
 it('returns an error on wrong scheme', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
     server.auth.strategy('default', 'basic', { validate: internals.user });
 
@@ -78,7 +78,7 @@ it('returns a reply on successful double auth', async () => {
         return res.result;
     };
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -105,7 +105,7 @@ it('returns a reply on successful double auth', async () => {
 
 it('returns a reply on failed optional auth', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
 
     await server.register(require('../'));
 
@@ -133,7 +133,7 @@ it('returns a reply on failed optional auth', async () => {
 
 it('returns an error on bad password', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -157,7 +157,7 @@ it('returns an error on bad password', async () => {
 
 it('returns an error on bad header format', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -184,7 +184,7 @@ it('returns an error on bad header format', async () => {
 
 it('returns an error on bad header internal syntax', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -211,7 +211,7 @@ it('returns an error on bad header internal syntax', async () => {
 
 it('returns an error on missing username', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -237,7 +237,7 @@ it('returns an error on missing username', async () => {
 
 it('allow missing username', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', {
@@ -264,7 +264,7 @@ it('allow missing username', async () => {
 
 it('returns an error on unknown user', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -289,7 +289,7 @@ it('returns an error on unknown user', async () => {
 
 it('replies with thrown custom error', async () => {
 
-    const server = new Hapi.Server({ debug: false });
+    const server = Hapi.server({ debug: false });
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -316,7 +316,7 @@ it('replies with thrown custom error', async () => {
 
 it('replies with takeover response', async () => {
 
-    const server = new Hapi.Server({ debug: false });
+    const server = Hapi.server({ debug: false });
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -342,7 +342,7 @@ it('replies with takeover response', async () => {
 
 it('returns an error on non-object credentials error', async () => {
 
-    const server = new Hapi.Server({ debug: false });
+    const server = Hapi.server({ debug: false });
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -368,7 +368,7 @@ it('returns an error on non-object credentials error', async () => {
 
 it('returns an error on missing credentials error', async () => {
 
-    const server = new Hapi.Server({ debug: false });
+    const server = Hapi.server({ debug: false });
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -394,7 +394,7 @@ it('returns an error on missing credentials error', async () => {
 
 it('returns an error on insufficient scope', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -423,7 +423,7 @@ it('returns an error on insufficient scope', async () => {
 
 it('returns an error on insufficient scope specified as an array', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -453,7 +453,7 @@ it('returns an error on insufficient scope specified as an array', async () => {
 
 it('authenticates scope specified as an array', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -482,7 +482,7 @@ it('authenticates scope specified as an array', async () => {
 
 it('should ask for credentials if server has one default strategy', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
 
 
@@ -514,7 +514,7 @@ it('should ask for credentials if server has one default strategy', async () => 
 
 it('cannot add a route that has payload validation required', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -543,7 +543,7 @@ it('cannot add a route that has payload validation required', async () => {
 
 it('cannot add a route that has payload validation as optional', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -572,7 +572,7 @@ it('cannot add a route that has payload validation as optional', async () => {
 
 it('can add a route that has payload validation as none', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', { validate: internals.user });
@@ -601,7 +601,7 @@ it('can add a route that has payload validation as none', async () => {
 
 it('includes additional attributes in WWW-Authenticate header', async () => {
 
-    const server = new Hapi.Server();
+    const server = Hapi.server();
     await server.register(require('../'));
 
     server.auth.strategy('default', 'basic', {

--- a/test/index.js
+++ b/test/index.js
@@ -314,7 +314,7 @@ it('replies with thrown custom error', async () => {
     expect(res.statusCode).to.equal(400);
 });
 
-it('replies with takeover response', async () => {
+it('replies with response response', async () => {
 
     const server = Hapi.server({ debug: false });
     await server.register(require('../'));
@@ -655,7 +655,7 @@ internals.user = async function (request, username, password, h) {
     }
 
     if (username === 'bob') {
-        return await Promise.resolve({ takeover: h.redirect('https://hapijs.com') });
+        return await Promise.resolve({ response: h.redirect('https://hapijs.com') });
     }
 
     if (username === 'invalid1') {


### PR DESCRIPTION
Would appreciate reviews from people more familiar with async/await etc to give feedback on the approach taken.

Main changes:

- Use of async/await
- Rename of `validateFunc` option to `validate`
- instead of returning `err, isValid, credentials` to validateFunc callback it now returns an object or throws an error
- Previous ability to return a non-err error in `err` position (e/g/ to support redirects) has been supported here by instead returning a ~~`takeover`~~`response` property of the return object. I did consider just having it return a response object but not sure there's a way to check if it is a response object in the scheme?

Closes #60 